### PR TITLE
Use heap_mem variable for JVM args in nomad plan

### DIFF
--- a/the-train.nomad
+++ b/the-train.nomad
@@ -37,7 +37,7 @@ job "the-train" {
 
         args = [
           "java",
-          "-Xmx4094m",
+          "-Xmx{{WEB_RESOURCE_HEAP_MEM}}m",
           "-Drestolino.files=target/web",
           "-jar target/*-jar-with-dependencies.jar",
         ]


### PR DESCRIPTION
### What

Use new heap_mem variable for JVM args in nomad plan to prevent app requesting too much memory

### How to review

Check correct vars are being used 

### Who can review

Anyone