### PR TITLE
feature/userns-mode

### DIFF
--- a/the-train.nomad
+++ b/the-train.nomad
@@ -37,7 +37,9 @@ job "the-train" {
       }
 
       config {
-        command = "${NOMAD_TASK_DIR}/start-task"
+        command     = "${NOMAD_TASK_DIR}/start-task"
+        image       = "{{ECR_URL}}:concourse-{{REVISION}}"
+        userns_mode = "host"
 
         args = [
           "java",
@@ -47,8 +49,6 @@ job "the-train" {
           "-Drestolino.files=target/web",
           "-jar target/*-jar-with-dependencies.jar",
         ]
-
-        image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
         port_map {
           http = 8080


### PR DESCRIPTION
### What

Use the host user namespace. As we require a read/write permissions for content, we'll use the hosts user namespace to ensure the container has the correct permissions to modify files on the volume.

### How to review

Code review. I've deployed this revision to `bleed` - check that publishing still works OK.

### Who can review

Not me.
