### PR TITLE
feature/job-restart-stanza

### DIFF
--- a/the-train.nomad
+++ b/the-train.nomad
@@ -29,6 +29,13 @@ job "the-train" {
       value     = "web.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "the-train" {
       driver = "docker"
 


### PR DESCRIPTION
### What

Add restart stanza to job plan. Once upgraded to Nomad 0.8.4 we can control how our jobs our restarted.

### How to review

Check the plan is valid with Nomad 0.8+ and looks OK.

### Who can review

Not me.
