### PR TITLE
Release/2.0.1

### DIFF
--- a/the-train.nomad
+++ b/the-train.nomad
@@ -37,7 +37,9 @@ job "the-train" {
       }
 
       config {
-        command = "${NOMAD_TASK_DIR}/start-task"
+        command     = "${NOMAD_TASK_DIR}/start-task"
+        image       = "{{ECR_URL}}:concourse-{{REVISION}}"
+        userns_mode = "host"
 
         args = [
           "java",
@@ -47,8 +49,6 @@ job "the-train" {
           "-Drestolino.files=target/web",
           "-jar target/*-jar-with-dependencies.jar",
         ]
-
-        image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
         port_map {
           http = 8080

--- a/the-train.nomad
+++ b/the-train.nomad
@@ -29,6 +29,13 @@ job "the-train" {
       value     = "web.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "the-train" {
       driver = "docker"
 


### PR DESCRIPTION
### What

In this release:
* Update the nomad plans for to run on new production:
  * Run the container under the hosts user namespace to ensure the container has the correct permissions to modify files
  * Add nomad restart stanza for nomad 0.8 running on new production environment

### How to review

Check that the correct commits have been included in this commit and that no details are missing under 'In this release'.

### Who can review

Anyone but me.
