### PR TITLE
Feature/performance gains

### DIFF
--- a/src/main/java/com/github/davidcarboni/thetrain/helpers/Configuration.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/helpers/Configuration.java
@@ -1,10 +1,6 @@
 package com.github.davidcarboni.thetrain.helpers;
 
-import com.github.davidcarboni.cryptolite.Keys;
-import com.github.davidcarboni.thetrain.logging.LogBuilder;
 import org.apache.commons.lang3.StringUtils;
-
-import static com.github.davidcarboni.thetrain.logging.LogBuilder.logBuilder;
 
 /**
  * Convenience class to get configuration values from {@link System#getProperty(String)} or gracefully fall back to {@link System#getenv()}.
@@ -15,6 +11,8 @@ public class Configuration {
     static final String TRANSACTION_STORE = "TRANSACTION_STORE";
     static final String WEBSITE_LEGACY = "thetrain.website";
     static final String WEBSITE = "WEBSITE";
+    static final String THREAD_POOL_SIZE = "POOL_SIZE";
+    static final int DEFAULT_THREAD_POOL_SIZE = 20;
 
     /**
      * Gets a configuration value from {@link System#getProperty(String)}, falling back to {@link System#getenv()}
@@ -35,4 +33,11 @@ public class Configuration {
         return StringUtils.defaultIfBlank(System.getenv(TRANSACTION_STORE), get(TRANSACTION_STORE_LEGACY));
     }
 
+    public static int threadPoolSize() {
+        try {
+            return Integer.parseInt(System.getenv(THREAD_POOL_SIZE));
+        } catch (NumberFormatException e) {
+            return DEFAULT_THREAD_POOL_SIZE;
+        }
+    }
 }

--- a/src/main/java/com/github/davidcarboni/thetrain/logging/LogBuilder.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/logging/LogBuilder.java
@@ -143,6 +143,11 @@ public class LogBuilder extends LogMessageBuilder {
         return this;
     }
 
+    public LogBuilder timeSince(long start) {
+        addParameter("timeTaken", System.currentTimeMillis() - start);
+        return this;
+    }
+
     /**
      * Add a parameter.
      */

--- a/src/main/java/com/github/davidcarboni/thetrain/logging/LogBuilder.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/logging/LogBuilder.java
@@ -143,8 +143,15 @@ public class LogBuilder extends LogMessageBuilder {
         return this;
     }
 
+    public LogBuilder performanceMetric(long start, String step) {
+        addParameter("performanceMetric", true);
+        addParameter("time", System.currentTimeMillis() - start);
+        addParameter("step", step);
+        return this;
+    }
+
     public LogBuilder timeSince(long start) {
-        addParameter("timeTaken", System.currentTimeMillis() - start);
+        addParameter("time", System.currentTimeMillis() - start);
         return this;
     }
 

--- a/src/main/java/com/github/davidcarboni/thetrain/storage/Publisher.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/storage/Publisher.java
@@ -315,6 +315,7 @@ public class Publisher {
         if (target != null) {
             Files.createDirectories(target.getParent());
             copyFile(source.toFile(), target.toFile());
+            moved = true;
         }
 
         // Update the transaction
@@ -427,16 +428,7 @@ public class Publisher {
             // NB We're using copy rather than move for two reasons:
             // - To be able to review a transaction after the fact and see all the files that were published
             // - If we use encryption we need to copy through a cipher stream to handle decryption
-
-            try (
-                    FileInputStream fis = new FileInputStream(source.toFile());
-                    FileOutputStream fos = new FileOutputStream(target.toFile());
-                    FileChannel sourceChannel = fis.getChannel();
-                    FileChannel destinationChannel = fos.getChannel()
-            ) {
-                destinationChannel.transferFrom(sourceChannel, 0, sourceChannel.size());
-            }
-
+            copyFile(source.toFile(), target.toFile());
             uriInfo.commit();
             result = true;
 

--- a/src/main/java/com/github/davidcarboni/thetrain/storage/ShutdownTask.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/storage/ShutdownTask.java
@@ -1,0 +1,21 @@
+package com.github.davidcarboni.thetrain.storage;
+
+import java.util.concurrent.ExecutorService;
+
+import static com.github.davidcarboni.thetrain.logging.LogBuilder.logBuilder;
+
+public class ShutdownTask extends Thread {
+
+    private final ExecutorService pool;
+
+    public ShutdownTask(ExecutorService pool) {
+        this.pool = pool;
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        logBuilder().info("shutting down Publisher Thread Pool");
+        pool.shutdown();
+    }
+}

--- a/src/main/java/com/github/davidcarboni/thetrain/storage/Transactions.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/storage/Transactions.java
@@ -35,11 +35,20 @@ public class Transactions {
     static final String CONTENT = "content";
     static final String BACKUP = "backup";
 
-    static final Map<String, Transaction> transactionMap = new ConcurrentHashMap<>();
-    static final Map<String, ExecutorService> transactionExecutorMap = new ConcurrentHashMap<>();
-
     static Path transactionStore;
+    static final ObjectMapper objectMapper;
+    static final Map<String, Transaction> transactionMap;
+    static final Map<String, ExecutorService> transactionExecutorMap;
 
+
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+        transactionMap = new ConcurrentHashMap<>();
+        transactionExecutorMap = new ConcurrentHashMap<>();
+    }
 
     /**
      * Creates a new transaction.
@@ -57,7 +66,7 @@ public class Transactions {
         Files.createDirectory(path);
         Path json = path.resolve(JSON);
         try (OutputStream output = Files.newOutputStream(json)) {
-            objectMapper().writeValue(output, transaction);
+            objectMapper.writeValue(output, transaction);
             Files.createDirectory(path.resolve(CONTENT));
             Files.createDirectory(path.resolve(BACKUP));
             log.info("transaction written to disk successfully");
@@ -112,7 +121,7 @@ public class Transactions {
                     if (transactionPath != null && Files.exists(transactionPath)) {
                         final Path json = transactionPath.resolve(JSON);
                         try (InputStream input = Files.newInputStream(json)) {
-                            result = objectMapper().readValue(input, Transaction.class);
+                            result = objectMapper.readValue(input, Transaction.class);
                         }
                     }
                 } else {
@@ -174,7 +183,7 @@ public class Transactions {
                                     final Path json = transactionPath.resolve(JSON);
 
                                     try (OutputStream output = Files.newOutputStream(json)) {
-                                        objectMapper().writeValue(output, read);
+                                        objectMapper.writeValue(output, read);
                                     }
                                 }
                                 result = true;
@@ -215,7 +224,7 @@ public class Transactions {
                             .info("writing transaction file");
 
                     try (OutputStream output = Files.newOutputStream(json)) {
-                        objectMapper().writeValue(output, read);
+                        objectMapper.writeValue(output, read);
                         log.info("writing transaction file completed successfully");
                     } catch (Exception e) {
                         log.addParameter("path", json.toString())
@@ -321,12 +330,5 @@ public class Transactions {
 
         }
         return transactionStore;
-    }
-
-    private static ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        return objectMapper;
     }
 }


### PR DESCRIPTION
### What

- Made Thread pool a static field instead of creating a new one each time the method is called - thats just silly.
- Made the Thread pool size configurable - env var `THREAD_POOL_SIZE` with a default of 20.
- Added a performance metics log method for consistent log messages.
- Added additional log messages to key publishing methods to capture metrics on each publish stage.
- Updated File copies using streams to use `FileChannel.transferTo()` - initial testing shows this was significantly faster (~70% - 75% faster)
- Updated `Transactions` class to use a single `ObjectMapper` instead of creating a new one each time.

### How to review

Publishing should work but should be faster.

### Who can review

@MikeData @janderson2 @ian-kent @sully90 
