### PR TITLE
removed constraint:meta.has_disk

### DIFF
--- a/the-train.nomad
+++ b/the-train.nomad
@@ -3,11 +3,6 @@ job "the-train" {
   region      = "eu"
   type        = "service"
 
-  constraint {
-    attribute = "${meta.has_disk}"
-    value     = true
-  }
-
   update {
     min_healthy_time = "30s"
     healthy_deadline = "2m"


### PR DESCRIPTION
### What

Updated nomad plans to removed operator:regexp and attribute:meta.has_disk.
Could not find dp-api-poc or dp-developer-poc.
https://trello.com/c/wKGU1LY5/3697-check-all-bau-services-nomad-plans

### How to review

???

### Who can review

james
