### PR TITLE
fix

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 mkdir -p target/website
 mkdir -p target/transactions
-export content_path="target/website"
-export transactions_path="target/transactions"
+export WEBSITE="/Users/dave/Desktop/zebedee-data/content/zebedee/master"
+export TRANSACTION_STORE="/Users/dave/Desktop/zebedee-data/content/zebedee/transactions"
+export PUBLISHING_THREAD_POOL_SIZE=100
+export PORT=8084
 export DP_COLOURED_LOGGING=true
 export DP_LOGGING_FORMAT=pretty_json
 export PUBLISHING_THREAD_POOL_SIZE=100
 
-JAVA_OPTS="-Xmx1024m -Xdebug -Xrunjdwp:transport=dt_socket,address=8004,server=y,suspend=n"
+JAVA_OPTS="-Xmx1024m -Xms1024m -Xdebug -Xrunjdwp:transport=dt_socket,address=8004,server=y,suspend=n"
 
 mvn package -DskipTests=true && \
 java $JAVA_OPTS \

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 mkdir -p target/website
 mkdir -p target/transactions
-export WEBSITE="/Users/dave/Desktop/zebedee-data/content/zebedee/master"
-export TRANSACTION_STORE="/Users/dave/Desktop/zebedee-data/content/zebedee/transactions"
-export PUBLISHING_THREAD_POOL_SIZE=100
-export PORT=8084
+export content_path="target/website"
+export transactions_path="target/transactions"
 export DP_COLOURED_LOGGING=true
 export DP_LOGGING_FORMAT=pretty_json
 export PUBLISHING_THREAD_POOL_SIZE=100

--- a/src/main/java/com/github/davidcarboni/thetrain/json/Transaction.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/json/Transaction.java
@@ -175,7 +175,6 @@ public class Transaction {
             updated.add(error);
 
             this.errors = updated;
-            errors.add(error);
         }
     }
 

--- a/src/main/java/com/github/davidcarboni/thetrain/json/Transaction.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/json/Transaction.java
@@ -19,10 +19,6 @@ import java.util.Set;
  */
 public class Transaction {
 
-    private final transient Object uriInfosLock = new Object();
-    private final transient Object uriDeletesLock = new Object();
-    private final transient Object errorsLock = new Object();
-
     public static final String STARTED = "started";
     public static final String PUBLISHING = "publishing";
     public static final String COMMIT_FAILED = "commit failed";
@@ -77,7 +73,7 @@ public class Transaction {
      * @return An unmodifiable set of the URIs in this transaction.
      */
     public Set<UriInfo> uris() {
-        synchronized (uriInfosLock) {
+        synchronized (this) {
             return Collections.unmodifiableSet(uriInfos);
         }
     }
@@ -86,7 +82,7 @@ public class Transaction {
      * @return An unmodifiable set of the URIs to delete in this transaction.
      */
     public Set<UriInfo> urisToDelete() {
-        synchronized (uriDeletesLock) {
+        synchronized (this) {
             return Collections.unmodifiableSet(uriDeletes);
         }
     }
@@ -95,7 +91,7 @@ public class Transaction {
      * @param newUri The URI to add to the set of URIs.
      */
     public void addUri(UriInfo newUri) {
-        synchronized (uriInfosLock) {
+        synchronized (this) {
             Set<UriInfo> updated = new HashSet<>(this.uriInfos);
             updated.add(newUri);
 
@@ -105,7 +101,7 @@ public class Transaction {
     }
 
     public void addUris(List<UriInfo> addedUris) {
-        synchronized (uriInfosLock) {
+        synchronized (this) {
             Set<UriInfo> updated = new HashSet<>(this.uriInfos);
             updated.addAll(addedUris);
 
@@ -120,7 +116,7 @@ public class Transaction {
      * @param delete
      */
     public void addUriDelete(UriInfo delete) {
-        synchronized (uriDeletesLock) {
+        synchronized (this) {
             Set<UriInfo> updated = new HashSet<>(this.uriDeletes);
             updated.add(delete);
 
@@ -130,7 +126,7 @@ public class Transaction {
     }
 
     public void addUriDeletes(List<UriInfo> deletes) {
-        synchronized (uriDeletesLock) {
+        synchronized (this) {
             Set<UriInfo> updated = new HashSet<>(this.uriDeletes);
             updated.addAll(deletes);
 
@@ -152,7 +148,7 @@ public class Transaction {
      * @return If {@link #errors} contains anything, or if any {@link UriInfo#error error} field in {@link #uriInfos} is not blank, true.
      */
     public boolean hasErrors() {
-        synchronized (errorsLock) {
+        synchronized (this) {
             boolean result = errors.size() > 0;
             for (UriInfo uriInfo : uriInfos) {
                 result |= StringUtils.isNotBlank(uriInfo.error());
@@ -165,7 +161,7 @@ public class Transaction {
      * @return An unmodifiable set of the URIs in this transaction.
      */
     public List<String> errors() {
-        synchronized (errorsLock) {
+        synchronized (this) {
             return Collections.unmodifiableList(errors);
         }
     }
@@ -174,7 +170,7 @@ public class Transaction {
      * @param error An error debug to be added to this transaction.
      */
     public void addError(String error) {
-        synchronized (errorsLock) {
+        synchronized (this) {
             List<String> updated = new ArrayList<>(this.errors);
             updated.add(error);
 
@@ -203,7 +199,7 @@ public class Transaction {
 
     @Override
     public String toString() {
-        synchronized (uriInfosLock) {
+        synchronized (this) {
             return id + " (" + uriInfos.size() + " URIs)";
         }
     }

--- a/src/main/java/com/github/davidcarboni/thetrain/json/Transaction.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/json/Transaction.java
@@ -92,18 +92,24 @@ public class Transaction {
     }
 
     /**
-     * @param uriInfo The URI to add to the set of URIs.
+     * @param newUri The URI to add to the set of URIs.
      */
-    public void addUri(UriInfo uriInfo) {
+    public void addUri(UriInfo newUri) {
         synchronized (uriInfosLock) {
-            uriInfos.add(uriInfo);
+            Set<UriInfo> updated = new HashSet<>(this.uriInfos);
+            updated.add(newUri);
+
+            uriInfos = updated;
             status = PUBLISHING;
         }
     }
 
-    public void addUris(List<UriInfo> infos) {
+    public void addUris(List<UriInfo> addedUris) {
         synchronized (uriInfosLock) {
-            uriInfos.addAll(infos);
+            Set<UriInfo> updated = new HashSet<>(this.uriInfos);
+            updated.addAll(addedUris);
+
+            uriInfos = updated;
             status = PUBLISHING;
         }
     }
@@ -111,17 +117,25 @@ public class Transaction {
     /**
      * Add a delete command to the transaction.
      *
-     * @param uriInfo
+     * @param delete
      */
-    public void addUriDelete(UriInfo uriInfo) {
+    public void addUriDelete(UriInfo delete) {
         synchronized (uriDeletesLock) {
-            uriDeletes.add(uriInfo);
+            Set<UriInfo> updated = new HashSet<>(this.uriDeletes);
+            updated.add(delete);
+
+            uriDeletes = updated;
+            status = PUBLISHING;
         }
     }
 
     public void addUriDeletes(List<UriInfo> deletes) {
         synchronized (uriDeletesLock) {
-            uriDeletes.addAll(deletes);
+            Set<UriInfo> updated = new HashSet<>(this.uriDeletes);
+            updated.addAll(deletes);
+
+            uriDeletes = updated;
+            status = PUBLISHING;
         }
     }
 
@@ -161,6 +175,10 @@ public class Transaction {
      */
     public void addError(String error) {
         synchronized (errorsLock) {
+            List<String> updated = new ArrayList<>(this.errors);
+            updated.add(error);
+
+            this.errors = updated;
             errors.add(error);
         }
     }


### PR DESCRIPTION
### What

Fix for concurrent modification error when attempting to publish large collections.

The inner transaction collection objects are now copied to a new collection object which is modified before assigning the original reference.

(yes I know I _badly_ misspelled _concurrency_ in my branch name...)
