### PR TITLE
Hotfix/add files stream issue

### DIFF
--- a/src/main/java/com/github/davidcarboni/thetrain/helpers/UnionInputStream.java
+++ b/src/main/java/com/github/davidcarboni/thetrain/helpers/UnionInputStream.java
@@ -152,6 +152,7 @@ public class UnionInputStream extends InputStream {
     public void close() throws IOException {
         logBuilder().info("calling close on union input stream");
         IOUtils.closeQuietly(a);
-        IOUtils.closeQuietly(b);
+        // TODO explain why this is not closed.
+        //IOUtils.closeQuietly(b);
     }
 }


### PR DESCRIPTION
Fix for current stream closed issue.

The `close` method on the File channel is also closing its `Inputstream` (which would normally be correct) in this case the inputstream is the `UnionInputStream` which consists of a buffered amount of bytes from the current zip entry and the `ZipInputStream`.
On close `UnionInputStream` will close both streams which is causing the error - we have not finished with the `ZipInputStream`. 

Change updates `UnionInputStream,close()`  to only close the buffered bytes `InputStream` but  *NOT* the `ZipInputStream`- this is fine as the zip stream will be closed by the API endpoint when complete so there is no worry about it being left open.

Also attempted to tidy up the code and make it less impossible to understand.