### PR TITLE
updated logger version to release/1.2.0, cleaned up logback.xml appen…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-logging</artifactId>
-            <version>master-25d3e73a4c-1</version>
+            <version>release~1.2.0</version>
         </dependency>
 
         <!-- Test -->

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,7 @@ export PORT=8084
 export DP_COLOURED_LOGGING=true
 export DP_LOGGING_FORMAT=pretty_json
 export PUBLISHING_THREAD_POOL_SIZE=100
+export FORMAT_LOGGING=true
 
 JAVA_OPTS="-Xmx1024m -Xms1024m -Xdebug -Xrunjdwp:transport=dt_socket,address=8004,server=y,suspend=n"
 

--- a/src/main/java/com/github/onsdigital/thetrain/App.java
+++ b/src/main/java/com/github/onsdigital/thetrain/App.java
@@ -50,10 +50,12 @@ import static spark.Spark.post;
 
 public class App {
 
+    private static final String FORMAT_LOGS_KEY = "FORMAT_LOGGING";
+
     static Map<String, String> ROUTES;
 
     public static void main(String[] args) {
-        LogSerialiser serialiser = new JacksonLogSerialiser();
+        LogSerialiser serialiser = getLogSerialiser();
         LogStore store = new MDCLogStore(serialiser);
         Logger logger = new LoggerImpl("the-train");
 
@@ -152,5 +154,10 @@ public class App {
     private static void registerGetHandler(String uri, Route route, ResponseTransformer transformer) {
         ROUTES.put(uri, "GET");
         get(uri, route, transformer);
+    }
+
+    private static LogSerialiser getLogSerialiser() {
+        boolean formatLogging = Boolean.valueOf(System.getenv(FORMAT_LOGS_KEY));
+        return new JacksonLogSerialiser(formatLogging);
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="JSONIFIED" class="ch.qos.logback.core.ConsoleAppender">
+    <property scope="context" name="default.logger.name" value="dp-logger-default"/>
+    <property scope="context" name="default.logger.formatted" value="false"/>
+
+    <!--
+        This appender wraps the original message in the dp-logging standards format ensuring consistency with our log
+        output and that they play nice with the log aggregator.
+    -->
+    <appender name="THIRD_PARTY_TO_DP_LOGGING" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.github.onsdigital.logging.v2.layout.ThirdPartyEventLayout">
                 <Pattern>%n%msg</Pattern>
@@ -9,7 +16,7 @@
         </encoder>
     </appender>
 
-    <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="DP_LOGGER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
                 %msg%n
@@ -18,11 +25,11 @@
     </appender>
 
     <logger name="the-train" level="info" additivity="false">
-        <appender-ref ref="JSON_STDOUT"/>
+        <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <root level="WARN">
-        <appender-ref ref="JSONIFIED"/>
+    <root level="info">
+        <appender-ref ref="THIRD_PARTY_TO_DP_LOGGING"/>
     </root>
 
 </configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property scope="context" name="default.logger.formatted" value="true"/>
+
+    <appender name="JSONIFIED" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.github.onsdigital.logging.v2.layout.ThirdPartyEventLayout">
+                <Pattern>%n%msg</Pattern>
+            </layout>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="the-train" level="info" additivity="false">
+        <appender-ref ref="JSON_STDOUT"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="JSON_STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
### What

- Updated `dp-logger` version to `release/1.2.0`
- Cleaned up `logback.xml` appender defs - 3rd party apps now log output in the `dp-logging`format standards. 
- Added `logback.xml` to tests dir - unit tests now log output 🎉 
