### PR TITLE
fix for maven build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
             </snapshots>
             <id>central</id>
             <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Fix for failing maven builds.

https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required