### PR TITLE
disable pretty logging by default and adjust 3rd party log level to info

### DIFF
--- a/src/main/java/com/github/onsdigital/thetrain/App.java
+++ b/src/main/java/com/github/onsdigital/thetrain/App.java
@@ -79,7 +79,7 @@ public class App {
     }
 
     private static void initLogging() throws LoggingException {
-        LogSerialiser serialiser = new JacksonLogSerialiser(true);
+        LogSerialiser serialiser = new JacksonLogSerialiser();
         LogStore store = new MDCLogStore(serialiser);
         Logger logger = new LoggerImpl("the-train");
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
         <appender-ref ref="JSON_STDOUT"/>
     </logger>
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="JSONIFIED"/>
     </root>
 


### PR DESCRIPTION
### What

- Disable pretty json by default - logstash requires logging to be non formatted.
- Changed the log level for 3rd party events from `WARN` to `INFO` to ensure maximum visibility of relevant info.
