### PR TITLE
updated dp-logging version to latest with fix for trace ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,10 +117,11 @@
             <version>1.2.2</version>
         </dependency>
 
+        <!-- logging -->
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-logging</artifactId>
-            <version>v1.4.0</version>
+            <version>v1.5.0</version>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
Updated to the latest version of dp-logging. Fixes incorrect trace IDs in log events.
