### PR TITLE
Fix maven issue (https now required)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
             </snapshots>
             <id>central</id>
             <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
### What

New docker image needed, builds won't work anymore unless maven uses https. This apply the fix in develop to master and only that fix. Just enough to get a build made.

### How to review

Check that the only change is that which fix maven dependency issues

### Who can review

Anyone except me
