### PR TITLE
updated log config

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="JSONIFIED" class="ch.qos.logback.core.ConsoleAppender">
+    <property scope="context" name="default.logger.name" value="the-train"/>
+    <property scope="context" name="default.logger.formatted" value="false"/>
+
+    <appender name="THIRD_PARTY_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.github.onsdigital.logging.v2.layout.ThirdPartyEventLayout">
                 <Pattern>%n%msg</Pattern>
@@ -9,7 +12,7 @@
         </encoder>
     </appender>
 
-    <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="DP_LOG_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
                 %msg%n
@@ -18,11 +21,11 @@
     </appender>
 
     <logger name="the-train" level="info" additivity="false">
-        <appender-ref ref="JSON_STDOUT"/>
+        <appender-ref ref="DP_LOG_APPENDER"/>
     </logger>
 
     <root level="INFO">
-        <appender-ref ref="JSONIFIED"/>
+        <appender-ref ref="THIRD_PARTY_APPENDER"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
Updated log config.
 - Set default logger name to `the-train` to ensure any log events triggered before the app has started have the correct namespace.
- Renamed the log appenders to have more sensible names.
