### PR TITLE
Change docker image to use latest openjdk8 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM openjdk:8
 
 # Add the build artifacts
 WORKDIR /usr/src

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM openjdk:8
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
### What

Swap out java image for official openjdk 8 image to get latest jvm container support.

### Who can review

Anyone but me.
