### PR TITLE
Thread leak fix pt1: added closeablepart + tests.

### DIFF
--- a/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePart.java
+++ b/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePart.java
@@ -28,7 +28,8 @@ public class CloseablePart implements Part, AutoCloseable {
     /**
      * Construct a new CloseablePart instance from the {@link Part} provided.
      *
-     * @param part the {@link Part} to decorate with {@link AutoCloseable} funcationality
+     * @param part          part the {@link Part} to decorate with {@link AutoCloseable} funcationality
+     * @param transactionID the publishing transaction ID this file upload part relates to.
      */
     public CloseablePart(Part part, String transactionID) {
         this.part = part;

--- a/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePart.java
+++ b/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePart.java
@@ -1,0 +1,125 @@
+package com.github.onsdigital.thetrain.helpers.uploads;
+
+import com.github.onsdigital.thetrain.exception.PublishException;
+
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import static com.github.onsdigital.thetrain.logging.TrainEvent.error;
+import static com.github.onsdigital.thetrain.logging.TrainEvent.info;
+
+/**
+ * Decorator class that extends a {@link Part} implementing the {@link AutoCloseable} interface. <b>Does not change
+ * or alter the functionality of underlying {@link Part}.</b>
+ * <p>
+ * <p>
+ * Invoking {@link CloseablePart#close()} will call {@link Part#delete()} deleting/cleaning up any temp storage/files
+ * used in handling the file upload request. Implementing the {@link AutoCloseable} inrerface allows this object to
+ * be used within a try-with-resources block providing a neat solution to ensure any resources created are cleaned up
+ * automatically.
+ */
+public class CloseablePart implements Part, AutoCloseable {
+
+    private Part part;
+    private final String transactionID;
+
+    /**
+     * Construct a new CloseablePart instance from the {@link Part} provided.
+     *
+     * @param part the {@link Part} to decorate with {@link AutoCloseable} funcationality
+     */
+    public CloseablePart(Part part, String transactionID) {
+        this.part = part;
+        this.transactionID = transactionID;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return part.getInputStream();
+    }
+
+    @Override
+    public String getContentType() {
+        return part.getContentType();
+    }
+
+    @Override
+    public String getName() {
+        return part.getName();
+    }
+
+    @Override
+    public String getSubmittedFileName() {
+        return part.getSubmittedFileName();
+    }
+
+    @Override
+    public long getSize() {
+        return part.getSize();
+    }
+
+    @Override
+    public void write(String fileName) throws IOException {
+        part.write(fileName);
+    }
+
+    @Override
+    public void delete() throws IOException {
+        part.delete();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return part.getHeader(name);
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        return part.getHeaders(name);
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        return part.getHeaderNames();
+    }
+
+    /**
+     * @return the raw {@link Part} used by this object.
+     */
+    public Part getPart() {
+        return part;
+    }
+
+    /**
+     * @return the publishing {@link com.github.onsdigital.thetrain.json.Transaction#id} this file upload part
+     * belongs to.
+     */
+    public String getTransactionID() {
+        return transactionID;
+    }
+
+    /**
+     * Close method fulfulling the {@link AutoCloseable} interface allowing this object to be used within a
+     * <i>try-with-resources</i> block.
+     * <p>
+     * If the decorated {@link Part} is null does nothing. Otherwise calls {@link Part#delete()} to clean up any temp
+     * resources/storage used in handling the file upload.
+     *
+     * @throws PublishException
+     */
+    @Override
+    public void close() throws PublishException {
+        try {
+            if (this.part != null) {
+                info().log("attempting to clean up tmp file");
+                this.part.delete();
+            }
+        } catch (Exception ex) {
+            // log error but don't throw
+            error().transactionID(transactionID)
+                    .exception(ex).log("error calling close on multipart file upload part");
+        }
+    }
+}

--- a/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePart.java
+++ b/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePart.java
@@ -114,7 +114,9 @@ public class CloseablePart implements Part, AutoCloseable {
     public void close() throws PublishException {
         try {
             if (this.part != null) {
-                info().log("attempting to clean up tmp file");
+                info().transactionID(transactionID)
+                        .log("attempting to clean up temp files/storaged created during file upload");
+
                 this.part.delete();
             }
         } catch (Exception ex) {

--- a/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePartSupplier.java
+++ b/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePartSupplier.java
@@ -1,0 +1,26 @@
+package com.github.onsdigital.thetrain.helpers.uploads;
+
+import com.github.onsdigital.thetrain.exception.BadRequestException;
+import com.github.onsdigital.thetrain.exception.PublishException;
+import com.github.onsdigital.thetrain.json.Transaction;
+import spark.Request;
+
+/**
+ * Defines an object for obtaining a file upload {@link CloseablePart} from a {@link Request}.
+ */
+@FunctionalInterface
+public interface CloseablePartSupplier {
+
+    /**
+     * Get a file {@link CloseablePart} from a file upload request.
+     *
+     * @param req         the {@link Request} to get the {@link CloseablePart} from. Required and cannot be null.
+     * @param transaction the publishing {@link Transaction} the file upload is being added too. Required and cannot
+     *                    be null.
+     * @return a {@link CloseablePart} for the uploaded file.
+     * @throws PublishException    unexpected error getting the {@link CloseablePart} from the request.
+     * @throws BadRequestException thrown if either request or transaction are null, the file upload part is
+     *                             null or invalid.
+     */
+    CloseablePart getFilePart(Request req, Transaction transaction) throws PublishException, BadRequestException;
+}

--- a/src/test/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePartTest.java
+++ b/src/test/java/com/github/onsdigital/thetrain/helpers/uploads/CloseablePartTest.java
@@ -1,0 +1,226 @@
+package com.github.onsdigital.thetrain.helpers.uploads;
+
+import com.github.onsdigital.thetrain.helpers.uploads.CloseablePart;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.Part;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class CloseablePartTest {
+
+    static final String TRANSACTION_ID = "138";
+
+    @Mock
+    private InputStream inputStream;
+
+    @Mock
+    private Part wrappedPart;
+
+    private CloseablePart part;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void getInputStream_shouldReturnWrappedPartInputStream() throws Exception {
+        when(wrappedPart.getInputStream())
+                .thenReturn(inputStream);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getInputStream(), equalTo(inputStream));
+
+        verify(wrappedPart, times(1)).getInputStream();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getContentType_shouldReturnWrappedPartContentType() {
+        String expected = "application/json";
+        when(wrappedPart.getContentType())
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getContentType(), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getContentType();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getName_shouldReturnWrappedPartName() {
+        String expected = "Bruce Wayne";
+        when(wrappedPart.getName())
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getName(), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getName();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getSubmittedFileName_shouldReturnWrappedPartSubmittedFileName() {
+        String expected = "expected.json";
+        when(wrappedPart.getSubmittedFileName())
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getSubmittedFileName(), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getSubmittedFileName();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getSize_shouldReturnWrappedPartSize() {
+        long expected = 666;
+        when(wrappedPart.getSize())
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getSize(), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getSize();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void write_shouldCallWrappedPartWrite() throws IOException {
+        String expected = "expected.json";
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+        new CloseablePart(wrappedPart, TRANSACTION_ID).write(expected);
+
+        verify(wrappedPart, times(1)).write(captor.capture());
+        assertThat(captor.getValue(), equalTo(expected));
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void delete_shouldCallWrappedPartDelete() throws IOException {
+        new CloseablePart(wrappedPart, TRANSACTION_ID).delete();
+
+        verify(wrappedPart, times(1)).delete();
+    }
+
+    @Test
+    public void getHeader_shouldReturnWrappedPartGetHeader() {
+        String name = "header name";
+        String expected = "Alfred Pennyworth";
+
+        when(wrappedPart.getHeader(name))
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getHeader(name), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getHeader(name);
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getHeaders_shouldReturnWrappedPartGetHeaders() {
+        String name = "header name";
+
+        ArrayList<String> expected = new ArrayList<String>() {{
+            add("Alfred Pennyworth");
+        }};
+
+        when(wrappedPart.getHeaders(name))
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getHeaders(name), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getHeaders(name);
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getHeaderNames_shouldReturnWrappedPartGetHeaderNames() {
+        ArrayList<String> expected = new ArrayList<String>() {{
+            add("Alfred Pennyworth");
+            add("Bruce Wayne");
+            add("Dick Grayson");
+        }};
+
+        when(wrappedPart.getHeaderNames())
+                .thenReturn(expected);
+
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getHeaderNames(), equalTo(expected));
+
+        verify(wrappedPart, times(1)).getHeaderNames();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void close_shouldCallWrappedPartDeleteIfNotNull() throws Exception {
+        new CloseablePart(wrappedPart, TRANSACTION_ID).close();
+
+        verify(wrappedPart, times(1)).delete();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void close_shouldDoNothingIfWrappedPartIsNull() throws Exception {
+        new CloseablePart(null, TRANSACTION_ID).close();
+
+        verifyZeroInteractions(wrappedPart);
+    }
+
+    @Test
+    public void close_shouldSwallowErrorIfWrappedPartDeleteThrowsAnException() throws Exception {
+        doThrow(new RuntimeException("boom"))
+                .when(wrappedPart)
+                .delete();
+
+        new CloseablePart(wrappedPart, TRANSACTION_ID).close();
+
+        verify(wrappedPart, times(1)).delete();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void close_shouldBeCalledAutomatiucallyWhenUsedInTryWithResources() throws Exception {
+        String expected = "Hello world";
+
+        when(wrappedPart.getInputStream())
+                .thenReturn(new ByteArrayInputStream(expected.getBytes()));
+
+        try (
+                CloseablePart cp = new CloseablePart(wrappedPart, TRANSACTION_ID);
+                InputStream in = cp.getInputStream()
+        ) {
+            String value = IOUtils.toString(in, StandardCharsets.UTF_8);
+            assertThat(value, equalTo(expected));
+        }
+
+        verify(wrappedPart, times(1)).delete();
+        verify(wrappedPart, times(1)).getInputStream();
+        verifyNoMoreInteractions(wrappedPart);
+    }
+
+    @Test
+    public void getPart_shouldReturnPart() {
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getPart(), equalTo(wrappedPart));
+    }
+
+    @Test
+    public void getTransactionID_shouldReturnTransactionID() {
+        assertThat(new CloseablePart(wrappedPart, TRANSACTION_ID).getTransactionID(), equalTo(TRANSACTION_ID));
+    }
+}


### PR DESCRIPTION
### Thead leak fix part 1.

Added new `CloseablePart` class + tests. A `Part` is an object in a `HttpServletRequest` holding the data for a multipart file upload. I've created a new instance of this type that implements the `AutoCloseable` interface. 

#### Why?
Large upload files will write their request body to temp files on disk to prevent huge amounts of data being held in memory. These temp are not deleted/cleaned up once the request completes leaving files consuming disk space - over time this added up.
The `close` method I've added will clean up any temp resources created during the upload. `AutoCloseable` allows the object to be used in a `try-with-resources` block which will automatically call `close`on completion or error - making our code a bit _sleeker_ .

### How to review
Code review should be sufficient. I've implemented a decorator pattern to wrap an instance of `Part` giving it the closable functionality. The existing functionality of this object is unaffected/unchanged but I have written tests to prove this

### Who can review
Anyone. Feel free to ask me questions or if you want to walk through it.
