### PR TITLE
added new file part supplier and unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,19 +37,19 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.3</version>
         </dependency>
 
-        <dependency>
+<!--        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>2.5</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.14.v20181114</version>
+            <version>9.4.34.v20201102</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,18 +40,11 @@
             <version>2.9.3</version>
         </dependency>
 
-<!--        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>-->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
             <version>9.4.34.v20201102</version>
         </dependency>
-
 
         <!-- http -->
         <dependency>

--- a/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplier.java
+++ b/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplier.java
@@ -1,0 +1,77 @@
+package com.github.onsdigital.thetrain.helpers.uploads;
+
+import com.github.onsdigital.thetrain.exception.BadRequestException;
+import com.github.onsdigital.thetrain.exception.PublishException;
+import com.github.onsdigital.thetrain.json.Transaction;
+import spark.Request;
+
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Part;
+import java.nio.file.Path;
+
+import static com.github.onsdigital.thetrain.logging.TrainEvent.info;
+
+/**
+ * Implementation of {@link CloseablePartSupplier} that retrieves a {@link CloseablePart} if it exists from a
+ * {@link Request}.
+ */
+public class FilePartSupplier implements CloseablePartSupplier {
+
+    static final String MULTIPART_CONFIG = "org.eclipse.jetty.multipartConfig";
+    static final String FILE_PART_NAME = "file";
+
+    private Path tmpDir;
+    private long maxFileSize;
+    private long maxRequestSize;
+    private int fileThresholdSize;
+
+    /**
+     * Construct a new instance of {@link FilePartSupplier}.
+     *
+     * @param tmpDir            a {@link Path} to location temp files will be created.
+     * @param maxFileSize       the maximum file upload size accepted by the API (in bytes). A value of -1 is unlimited.
+     * @param maxRequestSize    the maximum request size accepted by the API (in bytes). A value of -1 is unlimited.
+     * @param fileThresholdSize the threshold size for writing file uploads to temp files on disk (in MB). Uploads
+     *                          smaller than this will be held in memory.
+     */
+    public FilePartSupplier(Path tmpDir, long maxFileSize, long maxRequestSize, int fileThresholdSize) {
+        this.tmpDir = tmpDir;
+        this.maxFileSize = maxFileSize;
+        this.maxRequestSize = maxRequestSize;
+        this.fileThresholdSize = fileThresholdSize;
+    }
+
+    @Override
+    public CloseablePart getFilePart(Request req, Transaction t) throws PublishException, BadRequestException {
+        if (req == null) {
+            throw new PublishException("error getting file part from request as request was null");
+        }
+
+        if (t == null) {
+            throw new PublishException("error getting file part from request transaction expected but was null");
+        }
+
+        HttpServletRequest raw = req.raw();
+        if (raw == null) {
+            throw new PublishException("error getting file part from request as HttpServletRequest was null", t);
+        }
+
+        req.attribute(MULTIPART_CONFIG,
+                new MultipartConfigElement(tmpDir.toString(), maxFileSize, maxRequestSize, fileThresholdSize));
+
+        info().transactionID(t).log("parsing request body for file item");
+        Part part = null;
+        try {
+            part = raw.getPart(FILE_PART_NAME);
+        } catch (Exception ex) {
+            throw new BadRequestException(ex, "error attempting to retriving multipart file upload request body", t.id());
+        }
+
+        if (part == null) {
+            throw new BadRequestException("expected multipart file upload request body but was null", t.id());
+        }
+
+        return new CloseablePart(part, t.id());
+    }
+}

--- a/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplier.java
+++ b/src/main/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplier.java
@@ -65,7 +65,7 @@ public class FilePartSupplier implements CloseablePartSupplier {
         try {
             part = raw.getPart(FILE_PART_NAME);
         } catch (Exception ex) {
-            throw new BadRequestException(ex, "error attempting to retriving multipart file upload request body", t.id());
+            throw new BadRequestException(ex, "error attempting to retrieve multipart file upload request body", t.id());
         }
 
         if (part == null) {

--- a/src/test/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplierTest.java
+++ b/src/test/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplierTest.java
@@ -104,7 +104,7 @@ public class FilePartSupplierTest {
         try {
             supplier.getFilePart(request, transaction);
         } catch (BadRequestException ex) {
-            assertThat(ex.getMessage(), equalTo("error attempting to retriving multipart file upload request body"));
+            assertThat(ex.getMessage(), equalTo("error attempting to retrieve multipart file upload request body"));
             assertThat(ex.getCause(), equalTo(expected));
             assertThat(ex.getTransactionID(), equalTo(TRANS_ID));
             throw ex;

--- a/src/test/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplierTest.java
+++ b/src/test/java/com/github/onsdigital/thetrain/helpers/uploads/FilePartSupplierTest.java
@@ -1,0 +1,136 @@
+package com.github.onsdigital.thetrain.helpers.uploads;
+
+import com.github.onsdigital.thetrain.exception.BadRequestException;
+import com.github.onsdigital.thetrain.exception.PublishException;
+import com.github.onsdigital.thetrain.json.Transaction;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import spark.Request;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isNotNull;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.when;
+
+public class FilePartSupplierTest {
+
+    static final String TRANS_ID = "666";
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private HttpServletRequest raw;
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private Part part;
+
+    private FilePartSupplier supplier;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        supplier = new FilePartSupplier(Paths.get("tmp"), -1, -1, 1024*1024*10);
+
+        when(transaction.id())
+                .thenReturn("666");
+    }
+
+    @Test (expected = PublishException.class)
+    public void givenRequestIsNull_shouldThrowPublishingException() throws Exception {
+        try {
+            supplier.getFilePart(null, null);
+        } catch (PublishException ex) {
+            assertThat(ex.getMessage(), equalTo("error getting file part from request as request was null"));
+            throw ex;
+        }
+    }
+
+    @Test (expected = PublishException.class)
+    public void givenTransactionIsNull_shouldThrowPublishingException() throws Exception {
+        try {
+            supplier.getFilePart(request, null);
+        } catch (PublishException ex) {
+            assertThat(ex.getMessage(), equalTo("error getting file part from request transaction expected but was null"));
+            throw ex;
+        }
+    }
+
+    @Test (expected = PublishException.class)
+    public void givenRequestRawReturnsNull_shouldThrowPublishingException() throws Exception {
+        when(request.raw()).thenReturn(null);
+
+        try {
+            supplier.getFilePart(request, transaction);
+        } catch (PublishException ex) {
+            assertThat(ex.getMessage(), equalTo("error getting file part from request as HttpServletRequest was null"));
+            assertThat(ex.getTransaction(), equalTo(transaction));
+            throw ex;
+        }
+    }
+
+    @Test (expected = BadRequestException.class)
+    public void givenGetPartThrowsException_shouldThrowBadRequestException() throws Exception {
+        IOException expected = new IOException("get part error");
+
+        when(request.raw())
+                .thenReturn(raw);
+        when(raw.getPart(anyString()))
+                .thenThrow(expected);
+
+        try {
+            supplier.getFilePart(request, transaction);
+        } catch (BadRequestException ex) {
+            assertThat(ex.getMessage(), equalTo("error attempting to retriving multipart file upload request body"));
+            assertThat(ex.getCause(), equalTo(expected));
+            assertThat(ex.getTransactionID(), equalTo(TRANS_ID));
+            throw ex;
+        }
+    }
+
+    @Test (expected = BadRequestException.class)
+    public void givenGetPartReturnsNull_shouldThrowBadRequestException() throws Exception {
+        IOException expected = new IOException("get part error");
+
+        when(request.raw())
+                .thenReturn(raw);
+        when(raw.getPart(anyString()))
+                .thenReturn(null);
+
+        try {
+            supplier.getFilePart(request, transaction);
+        } catch (BadRequestException ex) {
+            assertThat(ex.getMessage(), equalTo("expected multipart file upload request body but was null"));
+            assertThat(ex.getTransactionID(), equalTo(TRANS_ID));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void givengetFilePartIsSuccessful_shouldReturnCloseablePart() throws Exception {
+        when(request.raw())
+                .thenReturn(raw);
+        when(raw.getPart(anyString()))
+                .thenReturn(part);
+
+        CloseablePart actual = supplier.getFilePart(request, transaction);
+
+        assertThat(actual, is(notNullValue()));
+        assertThat(actual.getPart(), equalTo(part));
+    }
+}


### PR DESCRIPTION
### Threak leak part 3

Added new `FilePartSupplier` implementation + unit tests. The `FilePartSupplier` object returns the multipart file object from the `HTTPServletRequest`. Code is not currently wired up or used.

### How to review
PR / run the unit tests `mvn clean package -U`

### Who can review

Anyone 