### PR TITLE
bump spring-test 5.2.6.RELEASE => 5.3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.2.6.RELEASE</version>
+            <version>5.3.8</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### What

Fixed [spring-core vulnerability](https://ossindex.sonatype.org/component/pkg:maven/org.springframework/spring-core@5.2.6.RELEASE?utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1) - bumped `5.2.6.RELEASE` => `5.3.8`

### How to review

- Check audit passes
- Check you can still successfully publish content

### Who can review

Anyone
