### PR TITLE
Add basic health check endpoint

### DIFF
--- a/src/main/java/com/github/onsdigital/thetrain/App.java
+++ b/src/main/java/com/github/onsdigital/thetrain/App.java
@@ -134,6 +134,8 @@ public class App {
 
         registerGetHandler("/contentHash", getContentHash(beans, cfg.isVerifyPublishEnabled()), transformer);
 
+        registerGetHandler("/health", getHealthHandler(), transformer);
+
         // Catch-all for any request not handled by the above routes.
         registerGetHandler("*", getNotFoundHandler(), transformer);
     }
@@ -165,6 +167,13 @@ public class App {
 
     private static Route getContentHash(Beans beans, boolean isFeatureEnabled) {
         return new GetContentHash(beans.getTransactionsService(), beans.getContentService(), isFeatureEnabled);
+    }
+
+    private static Route getHealthHandler() {
+        return (req, resp) -> {
+            resp.status(200);
+            return new Message("I am alive!");
+        };
     }
 
     private static Route getNotFoundHandler() {

--- a/the-train.nomad
+++ b/the-train.nomad
@@ -66,6 +66,13 @@ job "the-train" {
         name = "the-train"
         port = "http"
         tags = ["web"]
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
       }
 
       resources {


### PR DESCRIPTION
### What

Add a very basic health check for use in checking liveness of the app. This endpoint does not perform and dependency checks, instead it simply returns a 200 OK in order to allow us to prove that the app is running and listening.

There are no tests for the handlers and this PR does not attempt to remedy this as the value is extremely limited with this being such a simple endpoint.

### Who can review

!me
